### PR TITLE
Deploy legacy javascript application to github pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -34,6 +34,9 @@ jobs:
         working-directory: app
         run: npm run build
 
+      - name: Include legacy app in artifact
+        run: mkdir -p app/dist/legacy && cp seasonal-random-anime/index.html app/dist/legacy/index.html
+
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3
         with:

--- a/README.md
+++ b/README.md
@@ -61,12 +61,14 @@ Scripts:
 
 ## Deployment (GitHub Pages)
 - Workflow: `.github/workflows/pages.yml`
-- Deploys the static directory `seasonal-random-anime/` without a build step.
+- Builds the React app in `app/` and deploys `app/dist` to Pages.
+- Includes the legacy vanilla app at `app/dist/legacy/index.html`.
 - Trigger: push to `main` or run manually via the Actions tab.
 
-After the first successful Pages deployment, the site will be available at:
+After the first successful Pages deployment, the sites will be available at:
 ```
-https://mikhailsal.github.io/seasonal-random-anime/
+React app:  https://mikhailsal.github.io/seasonal-random-anime/
+Legacy app: https://mikhailsal.github.io/seasonal-random-anime/legacy/
 ```
 
 ## API and Rate Limits


### PR DESCRIPTION
Add a separate GitHub Pages deployment for the legacy JavaScript application to allow viewing it alongside the new React app.

---
<a href="https://cursor.com/background-agent?bcId=bc-a1da9f48-4066-408d-a1d3-2249ae5e498c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a1da9f48-4066-408d-a1d3-2249ae5e498c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

